### PR TITLE
Fix Windows heap corruption in Python bindings

### DIFF
--- a/simcoon-python-builder/CMakeLists.txt
+++ b/simcoon-python-builder/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 
 add_test(NAME simmit_test
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test/simmit_test
-         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/simmit_test/run_test.py)
+         COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test/simmit_test/run_test.py)
 
 # Set PYTHONPATH so the test can find the simcoon module
 # Point to parent directory of PYTHON_INSTALL_DIR since it contains the 'simcoon' package directory


### PR DESCRIPTION
## Summary
- Switch simmit tests to use pytest runner
- This commit demonstrates the Windows heap corruption issue (0xc0000374) that occurs when calling `sim.L_iso()` from Python

## Issue
The Python bindings crash on Windows with heap corruption (fatal exception 0xc0000374) due to inconsistent memory allocation/deallocation between:
- The simcoon C++ library (using standard Armadillo malloc/free)
- The Python bindings (using carma's NumPy-wrapped malloc/free)

## Test Plan
- [ ] CI tests will show the heap corruption failure
- [ ] Fix will be applied in a follow-up commit

**Note:** The fix is ready but will be committed separately to demonstrate the issue in CI first.